### PR TITLE
fix: apply gaussian blur correctly in y direction.

### DIFF
--- a/ara_plumes/models.py
+++ b/ara_plumes/models.py
@@ -583,13 +583,15 @@ def apply_gauss_space_blur(
 
         for i, frame in enumerate(arr):
             blurred_arr[i] = cv2.GaussianBlur(
-                frame, kernel_size, sigma_x, sigmaY=sigma_y
+                frame, ksize=kernel_size, sigmaX=sigma_x, sigmaY=sigma_y
             )
 
     else:
         blurred_arr = np.array(
             [
-                cv2.GaussianBlur(frame_i, kernel_size, sigma_x, sigmaY=sigma_y)
+                cv2.GaussianBlur(
+                    frame_i, ksize=kernel_size, sigmaX=sigma_x, sigmaY=sigma_y
+                )
                 for frame_i in arr
             ]
         )

--- a/ara_plumes/utils.py
+++ b/ara_plumes/utils.py
@@ -84,6 +84,7 @@ def circle_poly_intersection(r, x0, y0, a, b, c, real=True):
 # General Purpose functions #
 #############################
 
+
 # General Purpose functions
 def count_files(directory: str, extension: str) -> int:
     """
@@ -308,6 +309,7 @@ class VideoPointPicker:
 ###################
 # Post Processing #
 ###################
+
 
 # For saving frames as video
 def create_video(directory, output_file, fps=15, extension="png", folder="movies"):


### PR DESCRIPTION
Not sure if there's a need for a separate sigma_y and sigma_x, but they are currently passed to `cv2.GaussianBlur` as positional arguments (incorrectly).  What we pass as `sigma_y` is assigned to the parameter `dst` in `cv2.GaussianBlur` ([docs](apply_gauss_space_blur)).

[Current code](https://github.com/Jacob-Stevens-Haas/ARA-Plumes/blob/1edff6eb98e83f6c65c1c535b9f4f33d5a72e101/ara_plumes/models.py#L585):

```python
    if iterative:
        ...
            blurred_arr[i] = cv2.GaussianBlur(frame, kernel_size, sigma_x, sigma_y)

    else:
        ...
                cv2.GaussianBlur(frame_i, kernel_size, sigma_x, sigma_y)
```

# Example showing correct calling
```python
import matplotlib.pyplot as plt
import numpy as np
import cv2

noise = np.random.standard_normal((30,30))

bigblur = 1e5
smallblur = 1e-5
fig, axs = plt.subplots(1, 5, figsize=[10, 5])
axs[0].imshow(noise)
axs[1].imshow(cv2.GaussianBlur(noise, (11, 11), smallblur))
axs[2].imshow(cv2.GaussianBlur(noise, (11, 11), bigblur))
axs[3].imshow(cv2.GaussianBlur(noise, (11, 11), bigblur, smallblur))
axs[4].imshow(cv2.GaussianBlur(noise, (11, 11), bigblur, sigmaY=smallblur))
```
The first image is noise.  The second image is minimal, isotropic blur.  The third image is large, isotropic blur.  The fourth image is how `apply_gauss_space_blur` tries to create an anisotropic blur.  But you can see from the image, it doesn't.  The fifth image is the correct way to create an anisotropic blur.
![image](https://github.com/Jacob-Stevens-Haas/ARA-Plumes/assets/37048747/6697c7fb-b568-4993-9435-1e5ac8fc9d1b)

@MalachiteWind 
