### PR TITLE
Refactor/concentric-circle/_get_edge_points

### DIFF
--- a/ara_plumes/concentric_circle.py
+++ b/ara_plumes/concentric_circle.py
@@ -136,16 +136,13 @@ def _get_edge_points(
     for step in range(1, num_of_circs + 1):
         radius = step * radii
         contour_crosses = _find_intersections(contours, radius)
-        if len(contour_crosses) == 0:
+        if len(contour_crosses) <= 1:
             continue
 
         edge_candidates = _interpolate_intersections(
             contour_crosses, radius, orig_center
         )
         polar_candidates = _append_polar_angle(edge_candidates, orig_center)
-
-        if len(polar_candidates) == 1:
-            continue
 
         max_idx = np.argmax(polar_candidates[:, -1])
         min_idx = np.argmin(polar_candidates[:, -1])

--- a/ara_plumes/concentric_circle.py
+++ b/ara_plumes/concentric_circle.py
@@ -329,7 +329,7 @@ def _find_max_on_circle(
     at `center` with `radius`. Values restricted to those that fall within
     array.
 
-    Coordinates for circle calculated along linspace along horizontal axis.
+    Coordinates for circle calculated along linspace for horizontal axis.
 
     Parameters:
     ----------

--- a/ara_plumes/concentric_circle.py
+++ b/ara_plumes/concentric_circle.py
@@ -369,8 +369,9 @@ def _find_max_on_circle(
     def _find_max_val_and_idx(arr):
         max_value = np.max(arr)
         max_indices = np.where(arr == max_value)[0]
+        mid_max_index = max_indices[len(max_indices) // 2]
 
-        return max_value, max_indices
+        return max_value, mid_max_index
 
     def _generate_circle_coords(cx, cy, radius, n_points):
         if radius == 0:

--- a/ara_plumes/concentric_circle.py
+++ b/ara_plumes/concentric_circle.py
@@ -93,13 +93,31 @@ def concentric_circle(
     # Limit points to those within contours, plus origin #
     xy_points_no_origin = cast(Float2D, points_mean[1:, 1:])
     mask = _sol_in_contours(xy_points_no_origin, contours)
-    points_mean = cast(PlumePoints, np.vstack((points_mean[:0], points_mean[1:][mask])))
+    points_in_cont = points_mean[1:][mask]
+
+    if len(points_in_cont) == 0:
+        points_mean = cast(PlumePoints, points_mean[:1])
+    else:
+        points_mean = cast(
+            PlumePoints, np.vstack((points_mean[:1], points_mean[1:][mask]))
+        )
 
     contour_dists = _contour_distances(contours, orig_center)
 
     points_var1, points_var2 = _get_edge_points(
         num_of_circs, radii, contour_dists, orig_center
     )
+
+    if len(points_var1) == 0:
+        points_var1 = cast(PlumePoints, points_mean[:1])
+    else:
+        points_var1 = cast(PlumePoints, np.vstack((points_mean[:1], points_var1)))
+
+    if len(points_var2) == 0:
+        points_var2 = cast(PlumePoints, points_mean[:1])
+    else:
+        points_var2 = cast(PlumePoints, np.vstack((points_mean[:1], points_var2)))
+
     return points_mean, points_var1, points_var2
 
 

--- a/ara_plumes/concentric_circle.py
+++ b/ara_plumes/concentric_circle.py
@@ -142,7 +142,7 @@ def _get_edge_points(
         edge_candidates = _interpolate_intersections(
             contour_crosses, radius, orig_center
         )
-        polar_candidates = _add_polar_angle(edge_candidates, orig_center)
+        polar_candidates = _append_polar_angle(edge_candidates, orig_center)
 
         if len(polar_candidates) == 1:
             continue
@@ -158,7 +158,7 @@ def _get_edge_points(
 
 def _find_intersections(contours: list[PlumePoints], radius: float) -> set[PlumePoints]:
     """
-    Find pairs of points where set of points where they cross over certain radii value.
+    Find pairs of points where they cross over certain radii value.
 
     NOTE: In edge case where a point is exactly equal to radius, it is treated as
           greater than radius.
@@ -249,7 +249,7 @@ def _interpolate_intersections(
     return np.array(inter_points)
 
 
-def _add_polar_angle(
+def _append_polar_angle(
     edge_candidates: PlumePoints, orig_center: tuple[float, float]
 ) -> set[tuple[float, float, float, float]]:
     """

--- a/ara_plumes/concentric_circle.py
+++ b/ara_plumes/concentric_circle.py
@@ -2,7 +2,6 @@ from typing import cast
 
 import cv2
 import numpy as np
-from scipy.ndimage import gaussian_filter
 
 from .typing import Bool1D
 from .typing import ColorImage
@@ -24,8 +23,6 @@ def concentric_circle(
     rtol: float = 1e-2,
     atol: float = 1e-6,
     poly_deg: float = 2,
-    mean_smoothing: bool = True,
-    mean_smoothing_sigma: int = 2,
     quiet: bool = True,
 ) -> tuple[PlumePoints, PlumePoints, PlumePoints]:
     """
@@ -63,14 +60,6 @@ def concentric_circle(
         Specifying degree of polynomail to learn on points selected from
         concentric circle method.
 
-    mean_smoothing:
-        Applying additional gaussian filter to learned concentric circle
-        points. Only in y direction
-
-    mean_smoothing_sigma:
-        Sigma parameter to be passed into gaussian_filter function when
-        ``mean_smoothing = True``.
-
     quiet:
         suppresses error output
 
@@ -106,11 +95,6 @@ def concentric_circle(
         img_gray, num_of_circs, orig_center, radii, interior_scale, rtol, atol, quiet
     )
 
-    # Apply gaussian filtering to points in y direction
-    if mean_smoothing:
-        points_mean = _apply_mean_smoothing(points_mean, sigma=mean_smoothing_sigma)
-
-    #########################################
     # Check if points fall within a contour #
     # fix this
     xy_points_no_origin = points_mean[1:, 1:]
@@ -353,13 +337,6 @@ def _contour_distances(selected_contours: Contour_List, origin: tuple[int, int])
         contour_dist_list.append(contour_dist)
 
     return contour_dist_list
-
-
-def _apply_mean_smoothing(points, sigma):
-    smooth_x = points[:, 1]
-    smooth_y = gaussian_filter(points[:, 2], sigma=sigma)
-    points[:, 1:] = np.column_stack((smooth_x, smooth_y))
-    return points
 
 
 def _sol_in_contour(

--- a/ara_plumes/concentric_circle.py
+++ b/ara_plumes/concentric_circle.py
@@ -284,15 +284,13 @@ def _apply_concentric_search(
 ) -> PlumePoints:
     # Initialize numpy array to store center
     points_mean = np.zeros(shape=(num_of_circs + 1, 3))
-    zero_index = 0
-    val = 0
-    points_mean[0] = np.insert(orig_center, zero_index, val)
+    points_mean[0] = (0, *orig_center)
 
     # Plot first point on path
     _, center = _find_max_on_circle(img_gray, orig_center, radius=radii)
     # code to choose only one
 
-    points_mean[1] = np.insert(center, zero_index, radii)
+    points_mean[1] = (radii, *center)
 
     for step in range(2, num_of_circs + 1):
         radius = radii * step
@@ -318,13 +316,16 @@ def _apply_concentric_search(
         if error_occured:
             break
 
-        points_mean[step] = np.insert(center, zero_index, radius)
+        points_mean[step] = (radius, *center)
     return points_mean
 
 
 def _find_max_on_circle(
-    array: GrayImage, center: tuple[float, float], radius: float, n_points: int = None
-):
+    array: GrayImage,
+    center: tuple[float, float],
+    radius: float,
+    n_points: None | int = None,
+) -> tuple[float, tuple[int, int]]:
     """
     Find the max value (and index) of an `array` on a circle centered
     at `center` with `radius`. Values restricted to those that fall within

--- a/ara_plumes/concentric_circle.py
+++ b/ara_plumes/concentric_circle.py
@@ -22,7 +22,6 @@ def concentric_circle(
     interior_scale: float = 3 / 5,
     rtol: float = 1e-2,
     atol: float = 1e-6,
-    poly_deg: float = 2,
     quiet: bool = True,
 ) -> tuple[PlumePoints, PlumePoints, PlumePoints]:
     """
@@ -55,10 +54,6 @@ def concentric_circle(
         Relative and absolute tolerances. Used in np.isclose function in
         find_max_on_boundary and find_next_center functions.
         Checks if points are close to selected radii.
-
-    poly_deg:
-        Specifying degree of polynomail to learn on points selected from
-        concentric circle method.
 
     quiet:
         suppresses error output
@@ -129,7 +124,20 @@ def _get_edge_points(
 
 
 def _find_intersections(contours: list[PlumePoints], radius: float) -> set[PlumePoints]:
-    ...
+    """
+    Find pairs of points where set of points where they cross over certain radii value.
+    """
+    pairs_of_points = []
+    for contour in contours:
+        sign = contour[-1, 0] < radius
+        for point_idx, (cur_radius, *_) in enumerate(contour):
+            if sign ^ (cur_radius < radius):
+                pairs_of_points.append(
+                    np.vstack((contour[point_idx - 1], contour[point_idx]))
+                )
+                sign = not sign
+
+    return pairs_of_points
 
 
 def _interpolate_intersections(

--- a/ara_plumes/concentric_circle.py
+++ b/ara_plumes/concentric_circle.py
@@ -117,6 +117,7 @@ def _get_edge_points(
         contour_crosses = _find_intersections(contours, radius)
         edge_candidates = _interpolate_intersections(contour_crosses, radius)
         polar_candidates = polar_angle(edge_candidates, orig_center)
+
         # cw_edge_points.append(... find the max or min polar candidate)
         # ccw_edge_points.append(... find the max or min polar candidate)
     # return as PlumePoints type
@@ -178,6 +179,7 @@ def _interpolate_intersections(
         return bary_func
 
     def opt_alpha(x0, y0, x1, y1, cx, cy, r):
+        """return a that solves `||f(a) - (cx,cy)||**2 = radius`"""
         denominator = (x0 - x1) ** 2 + (y0 - y1) ** 2
         term1 = (cx - x1) * (x0 - x1)
         term2 = (cy - y1) * (y0 - y1)

--- a/ara_plumes/concentric_circle.py
+++ b/ara_plumes/concentric_circle.py
@@ -159,6 +159,9 @@ def _get_edge_points(
 def _find_intersections(contours: list[PlumePoints], radius: float) -> set[PlumePoints]:
     """
     Find pairs of points where set of points where they cross over certain radii value.
+
+    NOTE: In edge case where a point is exactly equal to radius, it is treated as
+          greater than radius.
     """
     pairs_of_points = []
     for contour in contours:

--- a/ara_plumes/concentric_circle.py
+++ b/ara_plumes/concentric_circle.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 import cv2
 import numpy as np
 from scipy.ndimage import gaussian_filter
@@ -94,21 +96,15 @@ def concentric_circle(
         the concentric circle with raddi r(k).
     """
 
-    # convert image to gray
     if len(img.shape) == 3:
         img_gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
     else:
         img_gray = img.copy()
+    img_gray = cast(GrayImage, img_gray)
 
-    ############################
-    # Apply Concentric Circles #
-    ############################
     points_mean = _apply_concentric_search(
         img_gray, num_of_circs, orig_center, radii, interior_scale, rtol, atol, quiet
     )
-    ##########################
-    # Apply poly fit to mean #
-    ##########################
 
     # Apply gaussian filtering to points in y direction
     if mean_smoothing:
@@ -116,7 +112,6 @@ def concentric_circle(
 
     #########################################
     # Check if points fall within a contour #
-    #########################################
     # fix this
     xy_points_no_origin = points_mean[1:, 1:]
     points_mean[1:] = points_mean[1:][
@@ -208,8 +203,15 @@ def _get_var_points(
 
 
 def _apply_concentric_search(
-    img_gray, num_of_circs, orig_center, radii, interior_scale, rtol, atol, quiet
-):
+    img_gray: GrayImage,
+    num_of_circs: int,
+    orig_center: tuple[float, float],
+    radii: int,
+    interior_scale: float,
+    rtol: float,
+    atol: float,
+    quiet: bool,
+) -> PlumePoints:
     # Initialize numpy array to store center
     points_mean = np.zeros(shape=(num_of_circs + 1, 3))
     zero_index = 0

--- a/ara_plumes/concentric_circle.py
+++ b/ara_plumes/concentric_circle.py
@@ -344,7 +344,8 @@ def _find_max_on_circle(
 
     n_points:
         number of points used in linspace for calculating coordinates points
-        of circle.
+        of circle. Values must be sufficiently high to cover all points
+        on circle. Safe minimum is 2/3*radius in pixel distance, rounded.
 
     Returns:
     -------

--- a/ara_plumes/concentric_circle.py
+++ b/ara_plumes/concentric_circle.py
@@ -215,7 +215,21 @@ def _interpolate_intersections(
 def polar_angle(
     edge_candidates: PlumePoints, orig_center: tuple[float, float]
 ) -> set[tuple[float, float, float, float]]:
-    ...
+    """
+    Returns angle from orig_center based on (x,y) position.
+    Branch cut `theta in [-pi, pi]`
+    """
+    cx, cy = orig_center
+
+    polar_points = []
+    for rad, x_pos, y_pos in edge_candidates:
+        dy = y_pos - cy
+        dx = x_pos - cx
+        theta = np.arctan2(dy, dx)
+
+        polar_points.append((rad, x_pos, y_pos, theta))
+
+    return np.array(polar_points)
 
 
 def _apply_concentric_search(

--- a/ara_plumes/concentric_circle.py
+++ b/ara_plumes/concentric_circle.py
@@ -100,18 +100,18 @@ def concentric_circle(
     mask = _sol_in_contours(xy_points_no_origin, contours)
     points_mean = cast(PlumePoints, np.vstack((points_mean[:0], points_mean[1:][mask])))
 
-    points_mean[:, 1:] -= orig_center
+    # points_mean[:, 1:] -= orig_center
 
-    # Checking Variance points #
-    poly_coef_mean = np.polyfit(points_mean[:, 1], points_mean[:, 2], deg=poly_deg)
+    # # Checking edge points #
+    # poly_coef_mean = np.polyfit(points_mean[:, 1], points_mean[:, 2], deg=poly_deg)
 
-    f_mean = (
-        lambda x: poly_coef_mean[0] * x**2 + poly_coef_mean[1] * x + poly_coef_mean[2]
-    )
+    # f_mean = (
+    #     lambda x: poly_coef_mean[0] * x**2 + poly_coef_mean[1] * x + poly_coef_mean[2]
+    # )
 
     contour_dist_list = _contour_distances(contours, orig_center)
 
-    # Initialize variance list to store points
+    # Initialize edge list to store points
     points_var1, points_var2 = _get_var_points(
         num_of_circs, radii, contours, contour_dist_list, orig_center, f_mean
     )
@@ -322,13 +322,16 @@ def _find_next_center(
     return max_value, max_indices
 
 
-def _contour_distances(selected_contours: Contour_List, origin: tuple[int, int]):
+def _contour_distances(
+    contours: Contour_List, origin: tuple[float, float]
+) -> list[PlumePoints]:
     """
     Gets L2 distances between array of contours and single point origin.
     """
     contour_dist_list = []
-    for contour in selected_contours:
-        contour_dist = np.sqrt(np.sum((contour - np.array(origin)) ** 2, axis=1))
+    for contour in contours:
+        distances = np.sqrt(np.sum((contour - np.array(origin)) ** 2, axis=1))
+        contour_dist = np.hstack((distances.reshape((-1, 1)), contour))
         contour_dist_list.append(contour_dist)
 
     return contour_dist_list

--- a/ara_plumes/models.py
+++ b/ara_plumes/models.py
@@ -252,7 +252,7 @@ class PLUME:
 
             mean_k, var1_k, var2_k = concentric_circle(
                 frame_k,
-                selected_contours=selected_contours,
+                contours=selected_contours,
                 orig_center=orig_center,
                 **concentric_circle_kws,
             )

--- a/ara_plumes/tests/test_all.py
+++ b/ara_plumes/tests/test_all.py
@@ -19,53 +19,6 @@ test_numpy_frames = np.array(
     [np.full((10, 10), i, dtype=np.uint8) for i in range(1, 11)]
 )
 
-
-def test_concentric_circle():
-    # create data
-    scale = 4
-    orig_center = (50, 200)
-    height, width = 400, 400
-    bw_img = np.zeros((height, width), dtype=np.uint8)
-
-    bw_img[25:376, 50] = 255 // scale
-    bw_img[25, 50:251] = 255 / scale
-    bw_img[375, 50:251] = 255 // scale
-    bw_img[25:376, 250] = 255 // scale
-
-    num_of_circs = 3
-    r = 50
-    for i in range(num_of_circs):
-        i += 2
-        bw_img[200, r * i] = 255
-
-    rectangle_plume = bw_img.copy()
-
-    # get result
-    selected_contours = get_contour(rectangle_plume)
-    result_mean, result_var1, result_var2 = concentric_circle(
-        rectangle_plume,
-        selected_contours=selected_contours,
-        orig_center=orig_center,
-        radii=r,
-        num_of_circs=num_of_circs,
-    )
-
-    # expected data
-    expected_mean = np.array(
-        [[0, 50, 200], [50, 100, 200], [100, 150, 200], [150, 200, 200]]
-    )
-    expected_var1 = np.array(
-        [[0, 50, 200], [50, 50, 250], [100, 50, 300], [150, 50, 350]]
-    )
-    expected_var2 = np.array(
-        [[0, 50, 200], [50, 50, 150], [100, 50, 100], [150, 50, 50]]
-    )
-
-    np.testing.assert_array_equal(expected_mean, result_mean)
-    np.testing.assert_array_equal(expected_var1, result_var1)
-    np.testing.assert_array_equal(expected_var2, result_var2)
-
-
 def test_get_contour():
     width, height = 400, 400
     square_img = np.zeros((width, height), dtype=np.uint8)

--- a/ara_plumes/tests/test_all.py
+++ b/ara_plumes/tests/test_all.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock
 import cv2
 import numpy as np
 
-from ..concentric_circle import concentric_circle
 from ara_plumes import models
 from ara_plumes import regressions
 from ara_plumes import utils
@@ -18,6 +17,7 @@ from ara_plumes.preprocessing import convert_video_to_numpy_array
 test_numpy_frames = np.array(
     [np.full((10, 10), i, dtype=np.uint8) for i in range(1, 11)]
 )
+
 
 def test_get_contour():
     width, height = 400, 400

--- a/ara_plumes/tests/test_concentric_circle.py
+++ b/ara_plumes/tests/test_concentric_circle.py
@@ -65,8 +65,9 @@ def test_find_max_on_circle():
         np.testing.assert_array_equal(amax, [x_dist[0], x_dist[0]])
 
 
-def test_get_edge_points_3_circles():
-    num_of_circs = 3
+def test_get_edge_points():
+    # Image of test
+    # https://www.desmos.com/calculator/umi82ahhey
     radii = 1
     contour_distances = [
         np.array(
@@ -79,13 +80,20 @@ def test_get_edge_points_3_circles():
         )
     ]
     orig_center = (1, -1)
-    result = _get_edge_points(num_of_circs, radii, contour_distances, orig_center)
-    expected = (
-        np.array([[2, 0, np.sqrt(3) - 1], [3, 0, 2 * np.sqrt(2) - 1]]),
-        np.array([[2, 2, np.sqrt(3) - 1], [3, 2, 2 * np.sqrt(2) - 1]]),
-    )
-    for e, r in zip(expected, result):
-        np.testing.assert_array_almost_equal(e, r)
+    ccw, cw = _get_edge_points(1, radii, contour_distances, orig_center)
+
+    # test empty array when no intersection is found.
+    assert len(ccw) == 0
+    assert len(cw) == 0
+
+    ccw, cw = _get_edge_points(3, radii, contour_distances, orig_center)
+
+    # test ccw points have greater angle than cw points.
+    for ccw_point, cw_point in zip(ccw, cw):
+        ccw_theta = np.arctan2(ccw_point[2], ccw_point[1])
+        cw_theta = np.arctan2(cw_point[2], cw_point[1])
+
+        assert ccw_theta >= cw_theta
 
 
 def test_contour_distances():

--- a/ara_plumes/tests/test_concentric_circle.py
+++ b/ara_plumes/tests/test_concentric_circle.py
@@ -1,11 +1,12 @@
 import numpy as np
 
+from ..concentric_circle import _add_polar_angle
 from ..concentric_circle import _contour_distances
 from ..concentric_circle import _find_intersections
 from ..concentric_circle import _find_max_on_boundary
+from ..concentric_circle import _get_edge_points
 from ..concentric_circle import _interpolate_intersections
 from ..concentric_circle import concentric_circle
-from ..concentric_circle import polar_angle
 from ..models import get_contour
 from ..typing import X_pos
 from ..typing import Y_pos
@@ -83,6 +84,29 @@ def test_find_max_on_boundary():
     np.testing.assert_array_almost_equal(expected[1], result[1])
 
 
+def test_get_edge_points_3_circles():
+    num_of_circs = 3
+    radii = 1
+    contour_distances = [
+        np.array(
+            [
+                [np.sqrt(2), 0, 0],
+                [np.sqrt(2), 2, 0],
+                [np.sqrt(10), 2, 2],
+                [np.sqrt(10), 0, 2],
+            ]
+        )
+    ]
+    orig_center = (1, -1)
+    result = _get_edge_points(num_of_circs, radii, contour_distances, orig_center)
+    expected = (
+        np.array([[2, 0, np.sqrt(3) - 1], [3, 0, 2 * np.sqrt(2) - 1]]),
+        np.array([[2, 2, np.sqrt(3) - 1], [3, 2, 2 * np.sqrt(2) - 1]]),
+    )
+    for e, r in zip(expected, result):
+        np.testing.assert_array_almost_equal(e, r)
+
+
 def test_contour_distances():
     contour = np.array([[0, 0], [0, 1]])
     origin = (1.0, 0.0)
@@ -92,13 +116,13 @@ def test_contour_distances():
     np.testing.assert_allclose(result, expected)
 
 
-def test_polar_angle():
+def test__add_polar_angle():
     edge_candidates = np.array(
         [[1, 1 / 2, np.sqrt(3) / 2], [1, -1 / 2, np.sqrt(3) / 2]]
     )
     orig_center = (0, 0)
 
-    result = polar_angle(edge_candidates, orig_center)
+    result = _add_polar_angle(edge_candidates, orig_center)
     expected = np.array(
         [
             [1, 1 / 2, np.sqrt(3) / 2, np.pi / 3],

--- a/ara_plumes/tests/test_concentric_circle.py
+++ b/ara_plumes/tests/test_concentric_circle.py
@@ -5,6 +5,7 @@ from ..concentric_circle import _find_intersections
 from ..concentric_circle import _find_max_on_boundary
 from ..concentric_circle import _interpolate_intersections
 from ..concentric_circle import concentric_circle
+from ..concentric_circle import polar_angle
 from ..models import get_contour
 from ..typing import X_pos
 from ..typing import Y_pos
@@ -89,6 +90,23 @@ def test_contour_distances():
     expected = [np.hstack((ranges, contour))]
     result = _contour_distances([contour], origin=origin)
     np.testing.assert_allclose(result, expected)
+
+
+def test_polar_angle():
+    edge_candidates = np.array(
+        [[1, 1 / 2, np.sqrt(3) / 2], [1, -1 / 2, np.sqrt(3) / 2]]
+    )
+    orig_center = (0, 0)
+
+    result = polar_angle(edge_candidates, orig_center)
+    expected = np.array(
+        [
+            [1, 1 / 2, np.sqrt(3) / 2, np.pi / 3],
+            [1, -1 / 2, np.sqrt(3) / 2, 2 * np.pi / 3],
+        ]
+    )
+
+    np.testing.assert_array_almost_equal(expected, result)
 
 
 def test_interpolate_intersections():

--- a/ara_plumes/tests/test_concentric_circle.py
+++ b/ara_plumes/tests/test_concentric_circle.py
@@ -1,0 +1,49 @@
+import numpy as np
+from ..concentric_circle import concentric_circle
+from ..models import get_contour
+
+def test_concentric_circle():
+    # create data
+    scale = 4
+    orig_center = (50, 200)
+    height, width = 400, 400
+    bw_img = np.zeros((height, width), dtype=np.uint8)
+
+    bw_img[25:376, 50] = 255 // scale
+    bw_img[25, 50:251] = 255 / scale
+    bw_img[375, 50:251] = 255 // scale
+    bw_img[25:376, 250] = 255 // scale
+
+    num_of_circs = 3
+    r = 50
+    for i in range(num_of_circs):
+        i += 2
+        bw_img[200, r * i] = 255
+
+    rectangle_plume = bw_img.copy()
+
+    # get result
+    selected_contours = get_contour(rectangle_plume)
+    result_mean, result_var1, result_var2 = concentric_circle(
+        rectangle_plume,
+        selected_contours=selected_contours,
+        orig_center=orig_center,
+        radii=r,
+        num_of_circs=num_of_circs,
+    )
+
+    # expected data
+    expected_mean = np.array(
+        [[0, 50, 200], [50, 100, 200], [100, 150, 200], [150, 200, 200]]
+    )
+    expected_var1 = np.array(
+        [[0, 50, 200], [50, 50, 250], [100, 50, 300], [150, 50, 350]]
+    )
+    expected_var2 = np.array(
+        [[0, 50, 200], [50, 50, 150], [100, 50, 100], [150, 50, 50]]
+    )
+
+    np.testing.assert_array_equal(expected_mean, result_mean)
+    np.testing.assert_array_equal(expected_var1, result_var1)
+    np.testing.assert_array_equal(expected_var2, result_var2)
+

--- a/ara_plumes/tests/test_concentric_circle.py
+++ b/ara_plumes/tests/test_concentric_circle.py
@@ -3,7 +3,7 @@ import numpy as np
 from ..concentric_circle import _add_polar_angle
 from ..concentric_circle import _contour_distances
 from ..concentric_circle import _find_intersections
-from ..concentric_circle import _find_max_on_boundary
+from ..concentric_circle import _find_max_on_circle
 from ..concentric_circle import _get_edge_points
 from ..concentric_circle import _interpolate_intersections
 from ..concentric_circle import concentric_circle
@@ -58,30 +58,16 @@ def test_concentric_circle():
     np.testing.assert_array_equal(expected_var2, result_var2)
 
 
-def test_find_max_on_boundary():
-    scale = 4
-    orig_center = (50, 200)
-    height, width = 400, 400
-    bw_img = np.zeros((height, width), dtype=np.uint8)
-
-    bw_img[25:376, 50] = 255 // scale
-    bw_img[25, 50:251] = 255 / scale
-    bw_img[375, 50:251] = 255 // scale
-    bw_img[25:376, 250] = 255 // scale
-
-    num_of_circs = 3
-    r = 50
-    for i in range(num_of_circs):
-        i += 2
-        bw_img[200, r * i] = 255
-
-    rectangle_plume = bw_img.copy()
-
-    expected = (255, np.array([100, 200]))
-    result = _find_max_on_boundary(rectangle_plume, orig_center, r=50)
-
-    np.testing.assert_equal(expected[0], result[0])
-    np.testing.assert_array_almost_equal(expected[1], result[1])
+def test_find_max_on_circle():
+    axis = np.arange(5).reshape(-1, 1)
+    # arr is surface u = x*y in positive quadrant
+    arr = axis @ axis.T
+    radii = [x_dist * np.sqrt(2) for x_dist in axis.flatten()]
+    for x_dist, radius in zip(axis, radii):
+        max_val, amax = _find_max_on_circle(arr, (0, 0), radius)
+        # Max should be on the diagonal, i.e. x = y
+        assert max_val == x_dist[0] ** 2
+        np.testing.assert_array_equal(amax, [x_dist[0], x_dist[0]])
 
 
 def test_get_edge_points_3_circles():

--- a/ara_plumes/tests/test_concentric_circle.py
+++ b/ara_plumes/tests/test_concentric_circle.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from ..concentric_circle import _add_polar_angle
+from ..concentric_circle import _append_polar_angle
 from ..concentric_circle import _contour_distances
 from ..concentric_circle import _find_intersections
 from ..concentric_circle import _find_max_on_circle
@@ -102,13 +102,13 @@ def test_contour_distances():
     np.testing.assert_allclose(result, expected)
 
 
-def test__add_polar_angle():
+def test_append_polar_angle():
     edge_candidates = np.array(
         [[1, 1 / 2, np.sqrt(3) / 2], [1, -1 / 2, np.sqrt(3) / 2]]
     )
     orig_center = (0, 0)
 
-    result = _add_polar_angle(edge_candidates, orig_center)
+    result = _append_polar_angle(edge_candidates, orig_center)
     expected = np.array(
         [
             [1, 1 / 2, np.sqrt(3) / 2, np.pi / 3],

--- a/ara_plumes/tests/test_concentric_circle.py
+++ b/ara_plumes/tests/test_concentric_circle.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from ..concentric_circle import _contour_distances
 from ..concentric_circle import _find_max_on_boundary
 from ..concentric_circle import concentric_circle
 from ..models import get_contour
@@ -75,3 +76,12 @@ def test_find_max_on_boundary():
 
     np.testing.assert_equal(expected[0], result[0])
     np.testing.assert_array_almost_equal(expected[1], result[1])
+
+
+def test_contour_distances():
+    contour = np.array([[0, 0], [0, 1]])
+    origin = (1.0, 0.0)
+    ranges = np.array([[1], [np.sqrt(2)]])
+    expected = [np.hstack((ranges, contour))]
+    result = _contour_distances([contour], origin=origin)
+    np.testing.assert_allclose(result, expected)

--- a/ara_plumes/tests/test_concentric_circle.py
+++ b/ara_plumes/tests/test_concentric_circle.py
@@ -3,6 +3,7 @@ import numpy as np
 from ..concentric_circle import _contour_distances
 from ..concentric_circle import _find_intersections
 from ..concentric_circle import _find_max_on_boundary
+from ..concentric_circle import _interpolate_intersections
 from ..concentric_circle import concentric_circle
 from ..models import get_contour
 from ..typing import X_pos
@@ -88,6 +89,27 @@ def test_contour_distances():
     expected = [np.hstack((ranges, contour))]
     result = _contour_distances([contour], origin=origin)
     np.testing.assert_allclose(result, expected)
+
+
+def test_interpolate_intersections():
+    contours = [
+        np.array(
+            [
+                [np.sqrt(2), 0, 0],
+                [np.sqrt(2), 2, 0],
+                [np.sqrt(10), 2, 2],
+                [np.sqrt(10), 0, 2],
+            ]
+        )
+    ]
+    orig_center = (1, -1)
+    radius = 2
+    contour_crosses = _find_intersections(contours, radius)
+    result = _interpolate_intersections(contour_crosses, radius, orig_center)
+
+    expected = np.array([[2, 0, np.sqrt(3) - 1], [2, 2, np.sqrt(3) - 1]])
+
+    np.testing.assert_array_almost_equal(expected, result)
 
 
 def test_find_intersections():

--- a/ara_plumes/tests/test_concentric_circle.py
+++ b/ara_plumes/tests/test_concentric_circle.py
@@ -29,7 +29,7 @@ def test_concentric_circle():
     selected_contours = get_contour(rectangle_plume)
     result_mean, result_var1, result_var2 = concentric_circle(
         rectangle_plume,
-        selected_contours=selected_contours,
+        contours=selected_contours,
         orig_center=orig_center,
         radii=r,
         num_of_circs=num_of_circs,

--- a/ara_plumes/tests/test_concentric_circle.py
+++ b/ara_plumes/tests/test_concentric_circle.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from ..concentric_circle import _contour_distances
+from ..concentric_circle import _find_intersections
 from ..concentric_circle import _find_max_on_boundary
 from ..concentric_circle import concentric_circle
 from ..models import get_contour
@@ -87,3 +88,57 @@ def test_contour_distances():
     expected = [np.hstack((ranges, contour))]
     result = _contour_distances([contour], origin=origin)
     np.testing.assert_allclose(result, expected)
+
+
+def test_find_intersections():
+    contours = [
+        np.array(
+            [
+                [np.sqrt(2), 0, 0],
+                [np.sqrt(2), 2, 0],
+                [np.sqrt(10), 2, 2],
+                [np.sqrt(10), 0, 2],
+            ]
+        )
+    ]
+
+    expected = [
+        np.array([[np.sqrt(10), 0, 2], [np.sqrt(2), 0, 0]]),
+        np.array([[np.sqrt(2), 2, 0], [np.sqrt(10), 2, 2]]),
+    ]
+    result = _find_intersections(contours, radius=2)
+
+    for r, e in zip(result, expected):
+        np.testing.assert_array_almost_equal(r, e)
+
+
+def test_find_intersections_2_contours():
+    contours_2 = [
+        np.array(
+            [
+                [np.sqrt(2), 0, 0],
+                [np.sqrt(2), 2, 0],
+                [np.sqrt(10), 2, 2],
+                [np.sqrt(10), 0, 2],
+            ]
+        ),
+        np.array(
+            [
+                [np.sqrt(2), 2, 0],
+                [np.sqrt(2), 2, -2],
+                [np.sqrt(10), 4, -2],
+                [np.sqrt(10), 4, 0],
+            ]
+        ),
+    ]
+
+    expected = [
+        np.array([[np.sqrt(10), 0, 2], [np.sqrt(2), 0, 0]]),
+        np.array([[np.sqrt(2), 2, 0], [np.sqrt(10), 2, 2]]),
+        np.array([[np.sqrt(10), 4, 0], [np.sqrt(2), 2, 0]]),
+        np.array([[np.sqrt(2), 2, -2], [np.sqrt(10), 4, -2]]),
+    ]
+    result = _find_intersections(contours_2, radius=2)
+
+    for r, e in zip(result, expected):
+        np.testing.assert_array_almost_equal(r, e)

--- a/ara_plumes/tests/test_concentric_circle.py
+++ b/ara_plumes/tests/test_concentric_circle.py
@@ -1,6 +1,9 @@
 import numpy as np
+
+from ..concentric_circle import _find_max_on_boundary
 from ..concentric_circle import concentric_circle
 from ..models import get_contour
+
 
 def test_concentric_circle():
     # create data
@@ -47,3 +50,28 @@ def test_concentric_circle():
     np.testing.assert_array_equal(expected_var1, result_var1)
     np.testing.assert_array_equal(expected_var2, result_var2)
 
+
+def test_find_max_on_boundary():
+    scale = 4
+    orig_center = (50, 200)
+    height, width = 400, 400
+    bw_img = np.zeros((height, width), dtype=np.uint8)
+
+    bw_img[25:376, 50] = 255 // scale
+    bw_img[25, 50:251] = 255 / scale
+    bw_img[375, 50:251] = 255 // scale
+    bw_img[25:376, 250] = 255 // scale
+
+    num_of_circs = 3
+    r = 50
+    for i in range(num_of_circs):
+        i += 2
+        bw_img[200, r * i] = 255
+
+    rectangle_plume = bw_img.copy()
+
+    expected = (255, np.array([100, 200]))
+    result = _find_max_on_boundary(rectangle_plume, orig_center, r=50)
+
+    np.testing.assert_equal(expected[0], result[0])
+    np.testing.assert_array_almost_equal(expected[1], result[1])

--- a/ara_plumes/tests/test_concentric_circle.py
+++ b/ara_plumes/tests/test_concentric_circle.py
@@ -4,12 +4,14 @@ from ..concentric_circle import _contour_distances
 from ..concentric_circle import _find_max_on_boundary
 from ..concentric_circle import concentric_circle
 from ..models import get_contour
+from ..typing import X_pos
+from ..typing import Y_pos
 
 
 def test_concentric_circle():
     # create data
     scale = 4
-    orig_center = (50, 200)
+    orig_center = (X_pos(50), Y_pos(200))
     height, width = 400, 400
     bw_img = np.zeros((height, width), dtype=np.uint8)
 

--- a/ara_plumes/tests/test_concentric_circle.py
+++ b/ara_plumes/tests/test_concentric_circle.py
@@ -23,16 +23,11 @@ def test_concentric_circle():
     bw_img[25, 50:251] = 255 / scale
     bw_img[375, 50:251] = 255 // scale
     bw_img[25:376, 250] = 255 // scale
+    bw_img[200, [100, 150, 200]] = 255
+    rectangle_plume = bw_img
 
     num_of_circs = 3
     r = 50
-    for i in range(num_of_circs):
-        i += 2
-        bw_img[200, r * i] = 255
-
-    rectangle_plume = bw_img.copy()
-
-    # get result
     selected_contours = get_contour(rectangle_plume)
     result_mean, result_var1, result_var2 = concentric_circle(
         rectangle_plume,
@@ -120,24 +115,23 @@ def test_append_polar_angle():
 
 
 def test_interpolate_intersections():
-    contours = [
-        np.array(
-            [
-                [np.sqrt(2), 0, 0],
-                [np.sqrt(2), 2, 0],
-                [np.sqrt(10), 2, 2],
-                [np.sqrt(10), 0, 2],
-            ]
-        )
-    ]
-    orig_center = (1, -1)
-    radius = 2
-    contour_crosses = _find_intersections(contours, radius)
+    contour_crosses = [np.array([[0, 0, 0], [2 * np.sqrt(2), 2, 2]])]
+    radius = np.sqrt(2)
+    orig_center = (0, 0)
     result = _interpolate_intersections(contour_crosses, radius, orig_center)
+    dist_to_origin = np.linalg.norm(result[0, 1:] - orig_center)
 
-    expected = np.array([[2, 0, np.sqrt(3) - 1], [2, 2, np.sqrt(3) - 1]])
+    # test distance from result to orig_center
+    np.testing.assert_equal(dist_to_origin, radius)
 
-    np.testing.assert_array_almost_equal(expected, result)
+    x0, y0 = contour_crosses[0][0, 1:]
+    x1, y1 = contour_crosses[0][1, 1:]
+    x_result, y_result = result[0, 1:]
+
+    slope1 = (y_result - y0) / (x_result - x0)
+    slope2 = (y1 - y_result) / (x1 - x_result)
+
+    np.testing.assert_equal(slope1, slope2)
 
 
 def test_find_intersections():

--- a/ara_plumes/typing.py
+++ b/ara_plumes/typing.py
@@ -24,6 +24,7 @@ X_pos = NewType("X_pos", int)
 Contour_List = List[np.ndarray[tuple[int, Literal[2]], np.dtype[Any]]]
 PlumePoints = np.ndarray[tuple[int, Literal[3]], NpFlt]
 
+Bool1D = np.ndarray[tuple[int], np.bool_]
 Float1D = np.ndarray[tuple[int], NpFlt]
 Float2D = np.ndarray[tuple[int, int], NpFlt]
 Float3D = np.ndarray[tuple[int, int, int], NpFlt]

--- a/ara_plumes/typing.py
+++ b/ara_plumes/typing.py
@@ -24,7 +24,7 @@ X_pos = NewType("X_pos", int)
 Contour_List = List[np.ndarray[tuple[int, Literal[2]], np.dtype[Any]]]
 PlumePoints = np.ndarray[tuple[int, Literal[3]], NpFlt]
 
-Bool1D = np.ndarray[tuple[int], np.dtype[np.bool]]
+Bool1D = np.ndarray[tuple[int], np.dtype[np.bool_]]
 Float1D = np.ndarray[tuple[int], NpFlt]
 Float2D = np.ndarray[tuple[int, int], NpFlt]
 Float3D = np.ndarray[tuple[int, int, int], NpFlt]

--- a/ara_plumes/typing.py
+++ b/ara_plumes/typing.py
@@ -24,7 +24,7 @@ X_pos = NewType("X_pos", int)
 Contour_List = List[np.ndarray[tuple[int, Literal[2]], np.dtype[Any]]]
 PlumePoints = np.ndarray[tuple[int, Literal[3]], NpFlt]
 
-Bool1D = np.ndarray[tuple[int], np.bool_]
+Bool1D = np.ndarray[tuple[int], np.dtype[np.bool]]
 Float1D = np.ndarray[tuple[int], NpFlt]
 Float2D = np.ndarray[tuple[int, int], NpFlt]
 Float3D = np.ndarray[tuple[int, int, int], NpFlt]


### PR DESCRIPTION
Method change for selecting 'edge' points on a given video frame based on identified contour.

Edge coordinates are identified first by finding the intersection of a concentric circle with radius, `rad`, and the interpolation between Cartesian coordinates from the plume contour (given as an ordered set of points). Interpolation is done in barycentric coordinates.  From the set of identified interpolated points two points are selected:
- `ccw_point`: the point with a maximal polar angle from plume leak source, `orig_center`
- `cw`: the point with minimal polar angle from plume leak source, `orig_center`

Branch cut for polar angles is $\theta \in [-\pi,\pi]$. 
If one (or none) points are identified from interpolation step, then point is discarded. 


