### PR TITLE
fix: move polar angle branch cut to [-pi/2, 3pi/2]

### DIFF
--- a/ara_plumes/concentric_circle.py
+++ b/ara_plumes/concentric_circle.py
@@ -253,7 +253,7 @@ def _append_polar_angle(
 ) -> set[tuple[float, float, float, float]]:
     """
     Appends angle from orig_center based on (x,y) position.
-    Branch cut `theta in [-pi, pi]`
+    Branch cut `theta in [-pi/2, 3pi/2]`
 
     Returns:
     -------
@@ -267,6 +267,8 @@ def _append_polar_angle(
         dy = y_pos - cy
         dx = x_pos - cx
         theta = np.arctan2(dy, dx)
+        if theta >= -np.pi and theta < -np.pi / 2:
+            theta += 2 * np.pi
 
         polar_points.append((rad, x_pos, y_pos, theta))
 

--- a/ara_plumes/concentric_circle.py
+++ b/ara_plumes/concentric_circle.py
@@ -255,7 +255,10 @@ def _append_polar_angle(
 ) -> set[tuple[float, float, float, float]]:
     """
     Appends angle from orig_center based on (x,y) position.
-    Branch cut `theta in [-pi/2, 3pi/2]`
+    Branch cut `theta in [pi/2, -3pi/2]`
+
+    This odd branch cut is based on the y-axis, in image coordinates,
+    being reversed.
 
     Returns:
     -------
@@ -269,8 +272,8 @@ def _append_polar_angle(
         dy = y_pos - cy
         dx = x_pos - cx
         theta = np.arctan2(dy, dx)
-        if theta >= -np.pi and theta < -np.pi / 2:
-            theta += 2 * np.pi
+        if theta > np.pi / 2 and theta <= np.pi:
+            theta -= 2 * np.pi
 
         polar_points.append((rad, x_pos, y_pos, theta))
 

--- a/ara_plumes/concentric_circle.py
+++ b/ara_plumes/concentric_circle.py
@@ -70,14 +70,16 @@ def concentric_circle(
         with radii r(k).
 
     points_var1:
-        Returns nx3 array containing observed points along upper envolope path,
-        i.e., above the mean path. The kth entry is of the form [r(k), x(k), y(k)],
+        Returns nx3 array containing observed points along the counter-clockwise
+        envolope path.  For a plume drifting to the left, this will be the edge
+        below the mean path. The kth entry is of the form [r(k), x(k), y(k)],
         i.e the coordinate (x,y) of the intersection with the plume contour along
         the concentric circle with raddi r(k).
 
     points_var2:
-        Returns nx3 array containing observed points along lower envolope path,
-        i.e., below the mean path. The kth entry is of the form [r(k), x(k), y(k)],
+        Returns nx3 array containing observed points along the clockwise
+        envolope path.  For a plume drifting to the left, this will be the edge
+        above the mean path. The kth entry is of the form [r(k), x(k), y(k)],
         i.e the coordinate (x,y) of the intersection with the plume contour along
         the concentric circle with raddi r(k).
     """

--- a/ara_plumes/models.py
+++ b/ara_plumes/models.py
@@ -249,7 +249,7 @@ class PLUME:
 
         for i, (_, frame_points) in enumerate(mean_points):
 
-            if decenter:
+            if decenter is not None:
                 frame_points[:, 1:] -= decenter
             try:
                 coef_time_series[i] = regress_frame_mean(

--- a/ara_plumes/models.py
+++ b/ara_plumes/models.py
@@ -166,11 +166,13 @@ class PLUME:
 
         var1_points:
             List of tuples containing frame count, k, and var1 points, (r(k),x(k),y(k)),
-            attained from frame k.
+            attained from frame k of the counter-clockwise edge of the plume.  For a
+            plume drifting left, that is the lower edge.
 
         var2_points:
             List of tuples containing frame count, k, and var2 points, (r(k),x(k),y(k)),
-            attained from frame k.
+            attained from frame k of the clockwise edge of the plume.  For a plume
+            drifting left, that is the upper edge.
 
         """
         mean_points = []

--- a/ara_plumes/tests/test_concentric_circle.py
+++ b/ara_plumes/tests/test_concentric_circle.py
@@ -107,7 +107,7 @@ def test_contour_distances():
 
 def test_append_polar_angle():
     edge_candidates = np.array(
-        [[1, 1 / 2, np.sqrt(3) / 2], [1, -1 / 2, np.sqrt(3) / 2]]
+        [[1, 1 / 2, np.sqrt(3) / 2], [1, -1 / 2, np.sqrt(3) / 2], [1, -1, -1e-15]]
     )
     orig_center = (0, 0)
 
@@ -116,6 +116,7 @@ def test_append_polar_angle():
         [
             [1, 1 / 2, np.sqrt(3) / 2, np.pi / 3],
             [1, -1 / 2, np.sqrt(3) / 2, 2 * np.pi / 3],
+            [1, -1, 0, np.pi],
         ]
     )
 

--- a/ara_plumes/tests/test_concentric_circle.py
+++ b/ara_plumes/tests/test_concentric_circle.py
@@ -90,8 +90,8 @@ def test_get_edge_points():
 
     # test ccw points have greater angle than cw points.
     for ccw_point, cw_point in zip(ccw, cw):
-        ccw_theta = np.arctan2(ccw_point[2], ccw_point[1])
-        cw_theta = np.arctan2(cw_point[2], cw_point[1])
+        ccw_theta = np.arctan2(ccw_point[2], -ccw_point[1])
+        cw_theta = np.arctan2(cw_point[2], -cw_point[1])
 
         assert ccw_theta >= cw_theta
 
@@ -115,8 +115,8 @@ def test_append_polar_angle():
     expected = np.array(
         [
             [1, 1 / 2, np.sqrt(3) / 2, np.pi / 3],
-            [1, -1 / 2, np.sqrt(3) / 2, 2 * np.pi / 3],
-            [1, -1, 0, np.pi],
+            [1, -1 / 2, np.sqrt(3) / 2, -4 * np.pi / 3],
+            [1, -1, 0, -np.pi],
         ]
     )
 


### PR DESCRIPTION
If you want to verify new test of branch fails on main, just check out the test file by itself.

Also, I noticed that we reversed the return order of the ccw/cw points.  `concentric_circle` said that the `points_var_1` was the upper envelope path, but it sends the ccw points from `_get_edge_points` (lower path, if plume drifting left).  This also fixes the docstrings to reflect as such.  This is OK because plumex.video_digest was already making a mistake, expecting the lower branch first.

