### PR TITLE
feat: Allow enforcing left/right poly inverse regression

### DIFF
--- a/ara_plumes/models.py
+++ b/ara_plumes/models.py
@@ -1,5 +1,6 @@
 import logging
 import warnings
+from typing import Literal
 from typing import Optional
 
 import cv2
@@ -205,6 +206,7 @@ class PLUME:
         mean_points: List[tuple[Frame, PlumePoints]],
         regression_method: str,
         poly_deg: int = 2,
+        direction: Literal["left", "right", "either"] = "either",
         decenter: Optional[tuple[X_pos, Y_pos]] = None,
     ) -> Float2D:
         """
@@ -227,6 +229,8 @@ class PLUME:
         poly_deg:
             degree of regression for all poly methods. Note 'linear' ignores this
             argument.
+        direction:
+            Direction for poly_inverse regression.
 
         decenter:
             Tuple to optionally subtract from from points prior to regression
@@ -254,7 +258,7 @@ class PLUME:
                 frame_points[:, 1:] -= decenter
             try:
                 coef_time_series[i] = regress_frame_mean(
-                    frame_points, regression_method, poly_deg
+                    frame_points, regression_method, poly_deg, direction
                 )
             except np.linalg.LinAlgError:
                 warnings.warn(


### PR DESCRIPTION
This allows one to enforce which direction of inverse polynomial to regress. Normally, the regression has a discontinuity between left/right directions, they have to be performed individually and compared.  This can sometimes result in the wrong direction being chosen due to noise.  However, if the direction is known a priori, we can choose the best model.

An alternative would be to expose left-poly-inv and right-poly-inv to the public API and have the user handle this, but that seems unnecessarily in the weeds